### PR TITLE
feat:Checking for licenses for the account to redirect them correctly

### DIFF
--- a/plugins/harness-ci-cd/src/components/MyComponent/MyComponent.tsx
+++ b/plugins/harness-ci-cd/src/components/MyComponent/MyComponent.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import {
   Box,
   CircularProgress,
@@ -603,6 +603,7 @@ function MyComponent() {
   const [pipelineList, setpipelineList] = useState<any[]>([]);
   const [toggle, setToggle] = useState(false);
   const [flag, setFlag] = useState(false);
+  const [licenses, setLicenses] = useState("cd");
   const classes = useStyles();
   const discoveryApi = useApi(discoveryApiRef);
   const config = useApi(configApiRef);
@@ -613,6 +614,23 @@ function MyComponent() {
     config.getOptionalBoolean('harness.disableRunPipeline') ?? false;
 
   const { projectId, orgId, accountId, pipelineId, serviceId} = useProjectSlugFromEntity();
+  async function getLicense(){
+    const response = await fetch(
+      `${await backendBaseUrl}/harness/gateway/ng/api/licenses/account?routingId=${
+        accountId
+      }&accountIdentifier=${
+        accountId
+      }`);
+      const data = await response.json();
+      if(data?.data?.allModuleLicenses?.CD.length == 0)
+      {
+        setLicenses("ci");
+      }
+
+  }
+  useEffect(() =>{
+    getLicense();
+  },[])
 
   async function getPipeLineByService() {
     const list = serviceId;
@@ -693,11 +711,13 @@ function MyComponent() {
       field: 'id',
       type: 'numeric',
       width: '80px',
-      render: useCallback((row: Partial<TableData>) => {
+      render: (row: Partial<TableData>) => {
         const link =
           `${baseUrl}ng/#/account/` +
           accountId +
-          '/ci/orgs/' +
+          '/' +
+          licenses +
+          '/orgs/' +
           orgId +
           '/projects/' +
           projectId +
@@ -712,16 +732,18 @@ function MyComponent() {
             <b>{id}</b>
           </Link>
         );
-      }, []),
+      },
     },
     {
       title: 'Pipeline Name',
       field: 'col1',
-      render: useCallback((row: Partial<TableData>) => {
+      render: (row: Partial<TableData>) => {
         const link =
           `${baseUrl}ng/#/account/` +
           accountId +
-          '/ci/orgs/' +
+          '/' +
+          licenses +
+          '/orgs/' +
           orgId +
           '/projects/' +
           projectId +
@@ -740,7 +762,7 @@ function MyComponent() {
           
 
         );
-      }, []),
+      },
 
       customFilterAndSearch: (term, row: Partial<TableData>) => {
         const temp = row?.name ?? '';


### PR DESCRIPTION
## Describe your changes
Added an API to check the licenses for the account,Which will help us to redirect them to their respective logs view on Harness.
This was added as some users might have only CI or only CD license.
## Checklist
- [ ] I've documented the changes in the PR description.
- [ ] I've tested this change either in PR or local environment.

## [Contributor license agreement](https://github.com/harness/backstage-plugins/blob/main/plugins/CONTRIBUTOR_LICENSE_AGREEMENT.md)
