### PR TITLE
fix: Update README.md with information on permissions and roles required for harness api token

### DIFF
--- a/plugins/harness-ci-cd/README.md
+++ b/plugins/harness-ci-cd/README.md
@@ -47,7 +47,7 @@ proxy:
 
 Notes:
 
-- Plugin uses token configured here to make Harness API calls. Make sure this token has the necessary permissions
+- Plugin uses token configured here to make Harness API calls. Make sure the user creating this API token has necessary permissions, which include `project view` permission along with `pipeline view` and `execute` permissions and same applies for service accounts as well it must have a role assigned that has the roles with adequate permissions as described before. 
 
 - Set the value of target to your on-prem URL if you are using the Harness on-prem offering
 


### PR DESCRIPTION
Added the information on roles and permission required while creating Harness API token.

## Describe your changes

## Checklist
- [ ] I've documented the changes in the PR description.
- [ ] I've tested this change either in PR or local environment.

## [Contributor license agreement](https://github.com/harness/backstage-plugins/blob/main/Contributor_License_Agreement.md)
