### PR TITLE
Removed the Private Tag for chaos plugin

### DIFF
--- a/plugins/harness-chaos/package.json
+++ b/plugins/harness-chaos/package.json
@@ -4,7 +4,7 @@
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
-  "private": true,
+  "private": false,
   "publishConfig": {
     "access": "public",
     "main": "dist/index.esm.js",


### PR DESCRIPTION
## Describe your changes
Need to make it a public package to publish it to npm. 

## Checklist
- [ ] I've documented the changes in the PR description.
- [ ] I've tested this change either in PR or local environment.

## [Contributor license agreement](https://github.com/harness/backstage-plugins/blob/main/Contributor_License_Agreement.md)
