### PR TITLE
fix: [IDP-3152]: CI/CD plugin fix when URL is incorrect

### DIFF
--- a/plugins/harness-ci-cd/src/hooks/useProjectSlugEntity.tsx
+++ b/plugins/harness-ci-cd/src/hooks/useProjectSlugEntity.tsx
@@ -86,15 +86,21 @@ export const useProjectSlugFromEntity = (
     }
 
     const serviceUrlParams: any = serviceUrlMatch(selectedPipelineUrl);
+    if (serviceUrlParams) {
+      return {
+        orgId: serviceUrlParams.params.orgId,
+        accountId: serviceUrlParams.params.accountId,
+        serviceId: serviceUrlParams.params.serviceId,
+        urlParams: serviceUrlParams,
+        baseUrl1: baseUrl1,
+        projectIds: serviceUrlParams.params.projectId as string,
+        envFromUrl: envFromUrl,
+      };
+    }
 
+    // Handle the case where neither URL pattern matches
     return {
-      orgId: serviceUrlParams.params.orgId,
-      accountId: serviceUrlParams.params.accountId,
-      serviceId: serviceUrlParams.params.serviceId,
-      urlParams: serviceUrlParams,
-      baseUrl1: baseUrl1,
-      projectIds: serviceUrlParams.params.projectId as string,
-      envFromUrl: envFromUrl,
+      error: 'Invalid URL format',
     };
   }
 


### PR DESCRIPTION
## Describe your changes

Improved error handling in CI/CD plugin when one of the configured URL is incorrect. When the configured service ID URL is not supported or doesn't return a match, the page shows a 'Could not find the pipeline' message instead of the entire plugin page breaking. 
Before:
![Screenshot 2024-06-26 at 5 28 51 PM](https://github.com/harness/backstage-plugins/assets/171808116/b2ce4243-6831-49ea-8d7f-38894816d2c5)
After fix: 
<img width="1792" alt="Screenshot 2024-07-11 at 3 42 43 PM" src="https://github.com/harness/backstage-plugins/assets/171808116/6279a0b5-6e82-4fc4-aecd-5747322f07c7">

## Checklist
- [ ] I've documented the changes in the PR description.
- [ ] I've tested this change either in PR or local environment.

## [Contributor license agreement](https://github.com/harness/backstage-plugins/blob/main/Contributor_License_Agreement.md)
