### PR TITLE
fix:[IDP-3422]: Fix for CD service URL with gitsync/remote setup

### DIFF
--- a/plugins/harness-ci-cd/src/hooks/useProjectSlugEntity.tsx
+++ b/plugins/harness-ci-cd/src/hooks/useProjectSlugEntity.tsx
@@ -31,7 +31,7 @@ export const useProjectSlugFromEntity = (
       );
 
       serviceUrlMatch = match(
-        '(.*)/account/:accountId/module/:module/orgs/:orgId/projects/:projectId/services/:serviceId/(.*)',
+        '(.*)/account/:accountId/module/:module/orgs/:orgId/projects/:projectId/services/:serviced?(.*)',
         {
           decode: decodeURIComponent,
         },
@@ -45,7 +45,7 @@ export const useProjectSlugFromEntity = (
       );
 
       serviceUrlMatch = match(
-        '(.*)/account/:accountId/all/orgs/:orgId/projects/:projectId/services/:serviceId/(.*)',
+        '(.*)/account/:accountId/all/orgs/:orgId/projects/:projectId/services/:serviced?(.*)',
         {
           decode: decodeURIComponent,
         },
@@ -59,7 +59,7 @@ export const useProjectSlugFromEntity = (
       );
 
       serviceUrlMatch = match(
-        '(.*)/account/:accountId/:module/orgs/:orgId/projects/:projectId/services/:serviceId/(.*)',
+        '(.*)/account/:accountId/:module/orgs/:orgId/projects/:projectId/services/:serviced?(.*)',
         {
           decode: decodeURIComponent,
         },

--- a/plugins/harness-ci-cd/src/hooks/useProjectSlugEntity.tsx
+++ b/plugins/harness-ci-cd/src/hooks/useProjectSlugEntity.tsx
@@ -31,7 +31,7 @@ export const useProjectSlugFromEntity = (
       );
 
       serviceUrlMatch = match(
-        '(.*)/account/:accountId/module/:module/orgs/:orgId/projects/:projectId/services/:serviceId',
+        '(.*)/account/:accountId/module/:module/orgs/:orgId/projects/:projectId/services/:serviceId/(.*)',
         {
           decode: decodeURIComponent,
         },
@@ -45,7 +45,7 @@ export const useProjectSlugFromEntity = (
       );
 
       serviceUrlMatch = match(
-        '(.*)/account/:accountId/all/orgs/:orgId/projects/:projectId/services/:serviceId',
+        '(.*)/account/:accountId/all/orgs/:orgId/projects/:projectId/services/:serviceId/(.*)',
         {
           decode: decodeURIComponent,
         },
@@ -59,7 +59,7 @@ export const useProjectSlugFromEntity = (
       );
 
       serviceUrlMatch = match(
-        '(.*)/account/:accountId/:module/orgs/:orgId/projects/:projectId/services/:serviceId',
+        '(.*)/account/:accountId/:module/orgs/:orgId/projects/:projectId/services/:serviceId/(.*)',
         {
           decode: decodeURIComponent,
         },

--- a/plugins/harness-ci-cd/src/hooks/useProjectSlugEntity.tsx
+++ b/plugins/harness-ci-cd/src/hooks/useProjectSlugEntity.tsx
@@ -31,7 +31,7 @@ export const useProjectSlugFromEntity = (
       );
 
       serviceUrlMatch = match(
-        '(.*)/account/:accountId/module/:module/orgs/:orgId/projects/:projectId/services/:serviced?(.*)',
+        '(.*)/account/:accountId/module/:module/orgs/:orgId/projects/:projectId/services/:serviceId?(.*)',
         {
           decode: decodeURIComponent,
         },
@@ -45,7 +45,7 @@ export const useProjectSlugFromEntity = (
       );
 
       serviceUrlMatch = match(
-        '(.*)/account/:accountId/all/orgs/:orgId/projects/:projectId/services/:serviced?(.*)',
+        '(.*)/account/:accountId/all/orgs/:orgId/projects/:projectId/services/:serviceId?(.*)',
         {
           decode: decodeURIComponent,
         },
@@ -59,7 +59,7 @@ export const useProjectSlugFromEntity = (
       );
 
       serviceUrlMatch = match(
-        '(.*)/account/:accountId/:module/orgs/:orgId/projects/:projectId/services/:serviced?(.*)',
+        '(.*)/account/:accountId/:module/orgs/:orgId/projects/:projectId/services/:serviceId?(.*)',
         {
           decode: decodeURIComponent,
         },


### PR DESCRIPTION
## Describe your changes
CI/CD plugin fix for service URL in case of remote/gitsync,
Example URL:  (.*)/account/:accountId/module/:module/orgs/:orgId/projects/:projectId/services/:serviceId?storeType=REMOTE&connectorRef=&repoName=<repo_name>&branch=<branch_name>

## Checklist
- [ ] I've documented the changes in the PR description.
- [ ] I've tested this change either in PR or local environment.

## [Contributor license agreement](https://github.com/harness/backstage-plugins/blob/main/Contributor_License_Agreement.md)
