### PR TITLE
fix: fixed incorrect plugin name in harness-chaos plugin readme

### DIFF
--- a/plugins/harness-chaos/README.md
+++ b/plugins/harness-chaos/README.md
@@ -13,7 +13,7 @@ Welcome to the Harness Chaos Engineering plugin for Backstage!
 1. Open terminal and navigate to the _root of your Backstage app_. Then run
 
 ```
-yarn add --cwd packages/app @harnessio/backstage-plugin-chaos
+yarn add --cwd packages/app @harnessio/backstage-plugin-harness-chaos
 
 yarn install
 ```


### PR DESCRIPTION
## Describe your changes

## Checklist
- [ ] I've documented the changes in the PR description.
- [ ] I've tested this change either in PR or local environment.

## [Contributor license agreement](https://github.com/harness/backstage-plugins/blob/main/Contributor_License_Agreement.md)
