### PR TITLE
fix: [CHAOS-7570]: fixed issues with Run Status Heat map in light mode

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -42,7 +42,7 @@
     "@harnessio/backstage-plugin-ci-cd": "^0.9.0",
     "@harnessio/backstage-plugin-feature-flags": "^0.2.0",
     "@harnessio/backstage-plugin-harness-srm": "^0.2.0",
-    "@harnessio/backstage-plugin-harness-chaos": "^0.1.0",
+    "@harnessio/backstage-plugin-harness-chaos": "^0.2.0",
     "@harnessio/backstage-plugin-harness-iacm": "0.3.0",
     "@harnessio/backstage-plugin-harness-ccm": "^0.1.0",
     "@material-ui/core": "^4.12.2",

--- a/plugins/harness-chaos/package.json
+++ b/plugins/harness-chaos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@harnessio/backstage-plugin-harness-chaos",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/harness-chaos/src/components/StatusHeatMap/StatusHeatMap.tsx
+++ b/plugins/harness-chaos/src/components/StatusHeatMap/StatusHeatMap.tsx
@@ -27,7 +27,7 @@ import { ExperimentRunStatus, RecentWorkflowRun } from '../../api/types';
 import { getIdentifiersFromUrl } from '../../utils/getIdentifiersFromUrl';
 import { useProjectUrlFromEntity } from '../../hooks/useGetSlugsFromEntity';
 
-const useStyles = makeStyles(() => ({
+const useStyles = makeStyles(theme => ({
   statusHeatMap: {
     display: 'flex',
     alignItems: 'end',
@@ -111,7 +111,7 @@ const useStyles = makeStyles(() => ({
     width: '300px',
     maxWidth: 400,
     overflow: 'auto',
-    backgroundColor: '#17293F',
+    backgroundColor: theme.palette.type === 'dark' ? '#17293F' : '#fff',
   },
 }));
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5172,10 +5172,10 @@
     path-to-regexp "^6.2.1"
     react-use "^17.2.4"
 
-"@harnessio/backstage-plugin-harness-chaos@^0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@harnessio/backstage-plugin-harness-chaos/-/backstage-plugin-harness-chaos-0.1.0.tgz#06bb0c5014cc7f4e3788d63a812dc1c4ce2b582c"
-  integrity sha512-dqn0ZShXxYUtirT8rL4QzqwPMmkJAm2W8VuA7fFk5fX7vEHbV/1W0X/eToAQvGxtagpEyNKuYC17VQlAAfuRnw==
+"@harnessio/backstage-plugin-harness-chaos@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@harnessio/backstage-plugin-harness-chaos/-/backstage-plugin-harness-chaos-0.2.0.tgz#0194db9f284dab06955f52b983b7c15f42363cf3"
+  integrity sha512-USlL+yHX5zexUJGZsD9B5upDZUbArcAqvsa5jBQ1Xd8F4OQU7g+hK/FQbt1HnvE87amanaIN+nzx5R+T+Mgq2Q==
   dependencies:
     "@backstage/catalog-model" "^1.4.5"
     "@backstage/core-components" "^0.14.0"
@@ -10217,7 +10217,7 @@ apg-lite@^1.0.3:
     "@harnessio/backstage-plugin-ci-cd" "^0.9.0"
     "@harnessio/backstage-plugin-feature-flags" "^0.2.0"
     "@harnessio/backstage-plugin-harness-ccm" "^0.1.0"
-    "@harnessio/backstage-plugin-harness-chaos" "^0.1.0"
+    "@harnessio/backstage-plugin-harness-chaos" "^0.2.0"
     "@harnessio/backstage-plugin-harness-iacm" "0.3.0"
     "@harnessio/backstage-plugin-harness-srm" "^0.2.0"
     "@material-ui/core" "^4.12.2"


### PR DESCRIPTION
## Describe your changes

<img width="321" alt="image" src="https://github.com/user-attachments/assets/4a538345-3c48-433c-89fe-5e4fbe84ae72" />

The background color in the popover in light mode was incorrect. This has now beed fixed.

<img width="341" alt="image" src="https://github.com/user-attachments/assets/ebf29f57-e785-4569-bef2-7cf0f326e70f" />


## Checklist
- [x] I've documented the changes in the PR description.
- [x] I've tested this change either in PR or local environment.

## [Contributor license agreement](https://github.com/harness/backstage-plugins/blob/main/Contributor_License_Agreement.md)
